### PR TITLE
Simple fix in basic http server example

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -17,7 +17,7 @@ httpServer.on('request', (req, res) => {
 		bareServer.routeRequest(req, res);
 	} else {
 		res.writeHead(400);
-		res.send('Not found.');
+		res.end('Not found.');
 	}
 });
 


### PR DESCRIPTION
res.send is in use, which as you know does not exist on a bare http server. Probably a typo