### PR TITLE
fix: mark JSONDatabaseAdapter as @internal in BareServer.ts

### DIFF
--- a/src/BareServer.ts
+++ b/src/BareServer.ts
@@ -12,6 +12,7 @@ import { Readable, type Duplex } from 'node:stream';
 import type { ReadableStream } from 'node:stream/web';
 import createHttpError from 'http-errors';
 import type WebSocket from 'ws';
+// @internal
 import type { JSONDatabaseAdapter } from './Meta.js';
 import { nullMethod } from './requestUtil.js';
 


### PR DESCRIPTION
...preventing a typescript compilation error
![image](https://github.com/tomphttp/bare-server-node/assets/58010778/3407de4b-c6ed-47a8-a5c6-49b64bb7bb5e)
