### PR TITLE
Added the cache-control to the list of forwareded headers

### DIFF
--- a/src/V1.ts
+++ b/src/V1.ts
@@ -213,6 +213,11 @@ const tunnelRequest: RouteCallback = async (request, res, options) => {
 				'content-length',
 				flattenHeader(response.headers[header]!),
 			);
+		else if (header === 'cache-control')
+		    responseHeaders.set(
+				'cache-control',
+				flattenHeader(response.headers[header]!),
+			)
 	}
 
 	responseHeaders.set(

--- a/src/V1.ts
+++ b/src/V1.ts
@@ -182,11 +182,11 @@ function readHeaders(request: BareRequest): BareHeaderData {
 const tunnelRequest: RouteCallback = async (request, res, options) => {
 	const abort = new AbortController();
 
-	request.native.on('close', () => {
+	request.native.on('abort', () => {
 		if (!request.native.complete) abort.abort();
 	});
 
-	res.on('close', () => {
+	res.on('abort', () => {
 		abort.abort();
 	});
 

--- a/src/V1.ts
+++ b/src/V1.ts
@@ -182,11 +182,11 @@ function readHeaders(request: BareRequest): BareHeaderData {
 const tunnelRequest: RouteCallback = async (request, res, options) => {
 	const abort = new AbortController();
 
-	request.native.on('abort', () => {
+	request.native.on('close', () => {
 		if (!request.native.complete) abort.abort();
 	});
 
-	res.on('abort', () => {
+	res.on('close', () => {
 		abort.abort();
 	});
 
@@ -214,7 +214,7 @@ const tunnelRequest: RouteCallback = async (request, res, options) => {
 				flattenHeader(response.headers[header]!),
 			);
 		else if (header === 'cache-control')
-		    responseHeaders.set(
+			responseHeaders.set(
 				'cache-control',
 				flattenHeader(response.headers[header]!),
 			)

--- a/src/V2.ts
+++ b/src/V2.ts
@@ -57,6 +57,7 @@ const defaultForwardHeaders: string[] = [
 	'sec-websocket-extensions',
 	'sec-websocket-key',
 	'sec-websocket-version',
+	'cache-control',
 ];
 
 const defaultPassHeaders: string[] = [

--- a/src/V3.ts
+++ b/src/V3.ts
@@ -46,7 +46,7 @@ const forbiddenPassHeaders: string[] = [
 ];
 
 // common defaults
-const defaultForwardHeaders: string[] = ['accept-encoding', 'accept-language'];
+const defaultForwardHeaders: string[] = ['accept-encoding', 'accept-language', 'cache-control'];
 
 const defaultPassHeaders: string[] = [
 	'content-encoding',

--- a/src/requestUtil.ts
+++ b/src/requestUtil.ts
@@ -104,8 +104,7 @@ export async function bareFetch(
 		});
 
 		outgoing.on('error', (error: Error) => {
-			// Reject only with the original error, not another error
-			reject(error);
+			reject(outgoingError(error));
 		});
 	});
 }

--- a/src/requestUtil.ts
+++ b/src/requestUtil.ts
@@ -21,38 +21,49 @@ export function randomHex(byteLength: number) {
 	return hex;
 }
 
-function outgoingError<T>(error: T): T | BareError {
-	if (error instanceof Error) {
-		switch ((<Error & { code?: string }>error).code) {
-			case 'ENOTFOUND':
-				return new BareError(500, {
-					code: 'HOST_NOT_FOUND',
-					id: 'request',
-					message: 'The specified host could not be resolved.',
-				});
-			case 'ECONNREFUSED':
-				return new BareError(500, {
-					code: 'CONNECTION_REFUSED',
-					id: 'response',
-					message: 'The remote rejected the request.',
-				});
-			case 'ECONNRESET':
-				return new BareError(500, {
-					code: 'CONNECTION_RESET',
-					id: 'response',
-					message: 'The request was forcibly closed.',
-				});
-			case 'ETIMEOUT':
-				return new BareError(500, {
-					code: 'CONNECTION_TIMEOUT',
-					id: 'response',
-					message: 'The response timed out.',
-				});
+async function outgoingError<T>(error: T): Promise<T | BareError> {
+	return new Promise((resolve, reject) => {
+		setTimeout(() => { // Simulating asynchronous operation
+			if (error instanceof Error) {
+				switch ((<Error & { code?: string }>error).code) {
+					case 'ENOTFOUND':
+						resolve(new BareError(500, {
+							code: 'HOST_NOT_FOUND',
+							id: 'request',
+							message: 'The specified host could not be resolved.',
+						}));
+						break;
+					case 'ECONNREFUSED':
+						resolve(new BareError(500, {
+							code: 'CONNECTION_REFUSED',
+							id: 'response',
+							message: 'The remote rejected the request.',
+						}));
+						break;
+					case 'ECONNRESET':
+						resolve(new BareError(500, {
+							code: 'CONNECTION_RESET',
+							id: 'response',
+							message: 'The request was forcibly closed.',
+						}));
+						break;
+					case 'ETIMEOUT':
+						resolve(new BareError(500, {
+							code: 'CONNECTION_TIMEOUT',
+							id: 'response',
+							message: 'The response timed out.',
+						}));
+						break;
+					default:
+						resolve(error);
+						break;
+				}
+		} else {
+			resolve(error);
 		}
-	}
-
-	return error;
-}
+		}, 0);
+	});
+  }
 
 export async function bareFetch(
 	request: BareRequest,


### PR DESCRIPTION
By adding the cache-control header to the list of forwarded headers, it allows common reverse proxy applications, such as Nginx and CloudFlare in proxy mode to utilize this header normally and cache responses from the Bare server to reduce load. This is beneficial for large-scale proxy servers because it allows for a reduction in system load on the origin without impacting user experience, with the usage of an appropriately formatted cache key that includes the custom HTTP headers used in the bare protocol.